### PR TITLE
Update ftx_sct_importer needsBaseForImport function to include additi…

### DIFF
--- a/library/ftx/ftx_sct_importer.pas
+++ b/library/ftx/ftx_sct_importer.pas
@@ -2136,7 +2136,15 @@ end;
 
 function needsBaseForImport(moduleId : String): boolean;
 begin
-  result := moduleId = '11000172109';
+  if (moduleId = '11000172109') // Belgium
+  or (moduleId = '554471000005108') // Denmark
+  or (moduleId = '11000146104') // Netherlands
+  or (moduleId = '45991000052106') // Sweden
+  or (moduleId = '999000041000000102') // UK
+  then
+    result := True
+  else
+    result := False;
 end;
 
 End.


### PR DESCRIPTION
…onal national SNOMED CT extenstions (previously only Belgium).  This allows importing the Danish extension and should also allow importing the Netherlands extension when available (the Swedish and UK extensions are also supported, but currently have some other issues with importing(