### PR TITLE
Change TSnomedImporter.SeeDesc to use StringIsInteger64 function

### DIFF
--- a/library/ftx/ftx_sct_importer.pas
+++ b/library/ftx/ftx_sct_importer.pas
@@ -1401,7 +1401,7 @@ var
 begin
   for s in sDesc.Split([',', ' ', ':', '.', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '{', '}', '[', ']', '|', '\', ';', '"', '<', '>', '?', '/', '~', '`', '-', '_', '-', '+', '=']) do
   begin
-    if (s <> '') And not StringIsInteger32(s) and (s.length > 2) Then
+    if (s <> '') And not StringIsInteger64(s) and (s.length > 2) Then
     begin
       stem := FStemmer.Stem(s);
       //if (stem <> '') then


### PR DESCRIPTION
Change TSnomedImporter.SeeDesc to use the StringIsInteger64 function (instead of StringIsInteger32).  This avoids an "out of range" error with embedded long integer values that may be present in some descriptions.  This issue was preventing importing the UK SNOMED CT Clinical Edition (extension).